### PR TITLE
Private APIを使わないオプションの追加

### DIFF
--- a/Ukam.xcodeproj/project.pbxproj
+++ b/Ukam.xcodeproj/project.pbxproj
@@ -381,6 +381,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 0.1.0;
+				OTHER_SWIFT_FLAGS = "\"-DUSE_UNDOCUMENTED_API\"";
 				PRODUCT_BUNDLE_IDENTIFIER = net.iseteki.Ukam;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Ukam/Bridge/Ukam-Bridging-Header.h";
@@ -407,6 +408,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 0.1.0;
+				OTHER_SWIFT_FLAGS = "\"-DUSE_UNDOCUMENTED_API\"";
 				PRODUCT_BUNDLE_IDENTIFIER = net.iseteki.Ukam;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Ukam/Bridge/Ukam-Bridging-Header.h";

--- a/Ukam/Bridge/AXUIElement.h
+++ b/Ukam/Bridge/AXUIElement.h
@@ -10,6 +10,7 @@
 
 #import <ApplicationServices/ApplicationServices.h>
 
+// undocumented api
 extern AXError _AXUIElementGetWindow(AXUIElementRef, CGWindowID* out);
 
 #endif /* AXUIElement_h */

--- a/Ukam/Managers/WindowManager.swift
+++ b/Ukam/Managers/WindowManager.swift
@@ -8,6 +8,8 @@
 import Cocoa
 import ScreenCaptureKit
 
+#if USE_UNDOCUMENTED_API
+
 func lookupWindowID(_ uiElement: AXUIElement) -> CGWindowID? {
     var windowId: CGWindowID = 0
     if _AXUIElementGetWindow(uiElement, &windowId) != .success {
@@ -15,6 +17,53 @@ func lookupWindowID(_ uiElement: AXUIElement) -> CGWindowID? {
     }
     return windowId
 }
+
+#else
+
+func lookupWindowPosition(_ axElement: AXUIElement) -> CGPoint {
+    var position: CFTypeRef?
+    if AXUIElementCopyAttributeValue(axElement, kAXPositionAttribute as CFString, &position) != .success {
+        return CGPoint.zero
+    }
+    let pos = position as! AXValue
+    var point = CGPoint.zero
+    AXValueGetValue(pos, .cgPoint, &point)
+    return point
+}
+
+func lookupWindowID(_ uiElement: AXUIElement) -> CGWindowID? {
+    // AXUIElementのプロセスIDを取得
+    var axPid: pid_t = 0
+    if AXUIElementGetPid(uiElement, &axPid) != .success {
+        return nil
+    }
+    
+    // すべてのウィンドウをリストアップ
+    let windowListOptions: CGWindowListOption = [.optionOnScreenOnly, .excludeDesktopElements]
+    guard let windowInfoList = CGWindowListCopyWindowInfo(windowListOptions, kCGNullWindowID) as NSArray? else { return nil }
+    
+    for windowInfo in windowInfoList as! [[String: AnyObject]] {
+        guard let windowID = windowInfo[kCGWindowNumber as String] as? CGWindowID,
+              let pid = windowInfo[kCGWindowOwnerPID as String] as? pid_t,
+              axPid == pid
+        else { continue }
+        
+        // ウィンドウの位置とサイズを取得
+        let position = windowInfo[kCGWindowBounds as String] as! [String: CGFloat]
+        let axPosition = lookupWindowPosition(uiElement)
+        
+        // 位置が一致するかどうかを確認
+        guard position["X"] == axPosition.x && position["Y"] == axPosition.y
+        else { continue }
+        
+//        print(windowInfo)
+        return windowID
+    }
+    
+    return nil
+}
+
+#endif
 
 func appAXUIElementContext(_ window: Window, handler: (AXUIElement) -> Void) {
     guard let pid = window.ownerPID else { return }
@@ -25,8 +74,9 @@ func appAXUIElementContext(_ window: Window, handler: (AXUIElement) -> Void) {
 func windowAXUIElementContext(_ window: Window, handler: (AXUIElement) -> Void) {
     appAXUIElementContext(window) { appElement in
         var arrayRef: CFArray?
-        AXUIElementCopyAttributeValues(appElement, kAXWindowsAttribute as CFString, 0, 9999, &arrayRef)
-        guard let elements = arrayRef as? [AXUIElement] else { return }
+        guard AXUIElementCopyAttributeValues(appElement, kAXWindowsAttribute as CFString, 0, 9999, &arrayRef) == .success,
+              let elements = arrayRef as? [AXUIElement]
+        else { return }
         for element in elements {
             guard let axWindowID = lookupWindowID(element),
                   let modelWindowID = window.number,

--- a/Ukam/Ukam.entitlements
+++ b/Ukam/Ukam.entitlements
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-</dict>
+<dict/>
 </plist>


### PR DESCRIPTION
Mac App Storeに出そうとしたが、Private APIを使っていたので出せなかった。
そもそもSandboxに入れると他のアプリを操作できなかった。

いずれにしてもストアに出せないのならPrivate API使ってても一緒なので#ifで切り替えられるようにする。