### PR TITLE
Sparkle導入に伴う署名処理の調整

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,10 +68,10 @@ jobs:
           xcodebuild -exportArchive -archivePath build/Ukam.xcarchive -exportPath build/ -exportOptionsPlist exportOptions.plist
           
           cd build/
-          zip -r Ukam.zip Ukam.app
-          zip -r Ukam.xcarchive.zip Ukam.xcarchive
+          /usr/bin/ditto -c -k --sequesterRsrc --keepParent Ukam.app Ukam.zip
+          /usr/bin/ditto -c -k --sequesterRsrc --keepParent Ukam.xcarchive Ukam.xcarchive.zip 
           mkdir dmgBase
-          cp -r Ukam.app dmgBase/
+          cp -Rp Ukam.app dmgBase/
           hdiutil create -volname Ukam -srcfolder dmgBase -ov -format UDZO Ukam.dmg
         env:
           DEVELOPER_DIR: /Applications/Xcode_15.3.app/Contents/Developer

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,10 +49,6 @@ jobs:
           echo '${{ secrets.ASC_KEY }}' > ~/private_keys/AuthKey_${{ secrets.ASC_KEY_ID }}.p8
           echo -n '${{ secrets.APPCAST_SIGN_KEY }}' > ~/private_keys/appcast_sign_key
 
-      - name: configure exportOptions.plist
-        run: |
-          /usr/libexec/PlistBuddy -c "Set :teamID ${{ secrets.MAC_TEAM_ID }}" exportOptions.plist
-
       - name: build macOS App
         run: |
           export MARKETING_VERSION=${MARKETING_VERSION_V#v}

--- a/Ukam.xcodeproj/project.pbxproj
+++ b/Ukam.xcodeproj/project.pbxproj
@@ -25,8 +25,8 @@
 		822CDF3E27D4C6CD00C6B331 /* MenuManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822CDF3D27D4C6CD00C6B331 /* MenuManager.swift */; };
 		822CDF4127D4C72E00C6B331 /* CGWindowModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822CDF4027D4C72E00C6B331 /* CGWindowModels.swift */; };
 		822CDF4427D4C79300C6B331 /* WindowManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822CDF4327D4C79300C6B331 /* WindowManager.swift */; };
-		822CDF4D27D5181D00C6B331 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 822CDF4C27D5181D00C6B331 /* CoreGraphics.framework */; platformFilter = maccatalyst; };
-		822CDF5027D52C1C00C6B331 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 822CDF4F27D52C1C00C6B331 /* ApplicationServices.framework */; platformFilter = maccatalyst; };
+		822CDF4D27D5181D00C6B331 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 822CDF4C27D5181D00C6B331 /* CoreGraphics.framework */; };
+		822CDF5027D52C1C00C6B331 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 822CDF4F27D52C1C00C6B331 /* ApplicationServices.framework */; };
 		82302D0F2C669E4300B8BF8C /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 82302D112C669E4300B8BF8C /* Localizable.strings */; };
 		82302D1D2C66A52C00B8BF8C /* RswiftLibrary in Frameworks */ = {isa = PBXBuildFile; productRef = 82302D1C2C66A52C00B8BF8C /* RswiftLibrary */; };
 		82479F7D2C709A100063996B /* SkyLightModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82479F7C2C709A100063996B /* SkyLightModels.swift */; };
@@ -101,9 +101,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				82479FAA2C71D9520063996B /* Sparkle in Frameworks */,
+				82302D1D2C66A52C00B8BF8C /* RswiftLibrary in Frameworks */,
 				822CDF4D27D5181D00C6B331 /* CoreGraphics.framework in Frameworks */,
 				82479FA62C71D4AE0063996B /* ServiceManagement.framework in Frameworks */,
-				82302D1D2C66A52C00B8BF8C /* RswiftLibrary in Frameworks */,
 				822CDF5027D52C1C00C6B331 /* ApplicationServices.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -608,6 +608,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				OTHER_CODE_SIGN_FLAGS = "--deep --timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = net.iseteki.Ukam;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Ukam/Bridge/Ukam-Bridging-Header.h";
@@ -634,6 +635,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				OTHER_CODE_SIGN_FLAGS = "--deep --timestamp";
 				PRODUCT_BUNDLE_IDENTIFIER = net.iseteki.Ukam;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Ukam/Bridge/Ukam-Bridging-Header.h";

--- a/exportOptions.plist
+++ b/exportOptions.plist
@@ -2,15 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>compileBitcode</key>
-	<true/>
 	<key>method</key>
 	<string>developer-id</string>
-	<key>signingCertificate</key>
-	<string>Developer ID Application</string>
 	<key>signingStyle</key>
-	<string>manual</string>
-	<key>teamID</key>
-	<string></string>
+	<string>automatic</string>
 </dict>
 </plist>


### PR DESCRIPTION
- exportOptionでmanualにしているとexport時に正しく署名されない
- zip -r で圧縮するとリソース情報が欠落してしまうのでdittoを使う必要がある

## 関連情報

- [TN2206 macOS Code Signing In Depth](https://developer.apple.com/library/archive/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG201)
- [The signature of the binary is invalid but codesign says otherwise](https://forums.developer.apple.com/forums/thread/116831)
- [Xcode11 以降のNotarizationの取得方法について](https://qiita.com/noby111/items/8ea98021bad1ea0470c8)
- notarytool の詳細ログは `xcrun notarytool log`